### PR TITLE
New Feature, Minor Updates

### DIFF
--- a/__tests__/words.test.js
+++ b/__tests__/words.test.js
@@ -8,7 +8,7 @@ describe('Profanity tests', () => {
 
     it('Should get all the profanity words in an array', () => {
         const allWords = profanity.all();
-        expect(allWords.length).toEqual(451);
+        expect(allWords.length).toEqual(958);
     });
 
     it('Should return true for profanity words', () => {
@@ -25,4 +25,15 @@ describe('Profanity tests', () => {
         const searchWord = profanity.search('');
         expect(searchWord).toEqual(false);
     });
+
+    it('Should return false for SFW string', () => {
+      const searchWord = profanity.searchWithin('hello world');
+      expect(searchWord).toEqual(false);
+    });
+
+    it('Should retrun true for NSFW string in sentence', () => {
+      const searchWord = profanity.searchWithin('hello world, fucker');
+      expect(searchWord).toEqual(true);
+    });
+
 });

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ export class ProfanityEngine {
             path = './node_modules/@coffeeandfun/google-profanity-words/data/list.txt';
         }
 
-        this.terms = fs.readFileSync(`${path}`, 'utf8').split('\n');
+        this.terms = fs.readFileSync(`${path}`, 'utf8').replace(/\r/g, "").split('\n');
     }
 
     all() {
@@ -20,5 +20,23 @@ export class ProfanityEngine {
     search(term) {
         let result = this.terms.indexOf(term);
         return result > -1 ? true : false
+    }
+
+    searchWithin(term) {
+      for (let i = 0; i < this.terms.length; i++) {
+        if (term.includes(this.terms[i])) {
+          // while this determines that the profanity is within our term, it may result in false positives
+          // hello - hell : true
+          // So we will use Regex, to check if the profanity is
+          // followed by -, _, *, a space, or a capital character like we see in camelCase,
+          // or the end of the string.
+          let re = `(${this.terms[i]})(\\s|\\-|\\_|\\*|[A-Z]|$)`;
+          let reg = new RegExp(re, "g");
+          if (reg.test(term)) {
+            return true;
+          }
+        }
+      }
+      return false;
     }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
+    "test": "set NODE_OPTIONS=--experimental-vm-modules&& jest"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I've added a new feature `searchWithin` used to determine if a term has profanity within it. This happens by first checking if profanity is within the term provided, and if so, uses Regex to check that the profanity is followed by `-`, `_`, `*`, a space, end of the string, or camelCase capitalization. 

Additionally the tests for this new function are included, as well as updated previous tests, that checked the amount of profanity words within the array.

And lastly some better cross-platform support, by using `SET` during setting environment variables during testing, and replacing carriage returns within the profanity file when reading.