### PR TITLE
Add function to get list of found curse words

### DIFF
--- a/__tests__/engine.test.js
+++ b/__tests__/engine.test.js
@@ -46,4 +46,16 @@ describe('ProfanityEngine Functions tests', () => {
     let terms = await profanity.all();
     expect(terms.length).toEqual(959);
   });
+
+  it('Should return list of found profanity words', async () => {
+    const sentence = 'This is a test sentence with bad words like hell and damn';
+    const badWords = await profanity.getCurseWords(sentence);
+    expect(badWords).toEqual(['hell', 'damn']);
+  });
+
+  it('Should return empty array if no curse words found', async () => {
+    const sentence = 'This is a test sentence with no bad words';
+    const result = await profanity.getCurseWords(sentence);
+    expect(result).toEqual([]);
+  });
 });

--- a/index.js
+++ b/index.js
@@ -80,6 +80,26 @@ export class ProfanityEngine {
     return false;
   }
 
+  async getCurseWords(sentence) {
+    if (this.terms.length === 0) {
+      await this.initialize();
+    }
+
+    let foundCurseWords = [];
+
+    const wordsInSentence = sentence.split(/\s+/);
+    const lowerCasedTerms = this.terms.map((term) => term.toLowerCase());
+
+    for (const word of wordsInSentence) {
+      const lowerCasedWord = word.toLowerCase();
+      if (lowerCasedTerms.includes(lowerCasedWord)) {
+        foundCurseWords.push(word);
+      }
+    }
+
+    return foundCurseWords;
+  }
+
   async all() {
     if (this.terms.length === 0) {
       await this.initialize();


### PR DESCRIPTION
## Description

This PR adds a new function to get the list of found profound words: `getCurseWords`. 

## Context 

I had a lengthy file filled with content that apparently contained words Google considers profane. I wanted not only to know if there were profane words in the text but also to identify them so I could find and replace them. Therefore, I created this function for my own use and thought it might be beneficial for others as well :)

